### PR TITLE
Add task to copy ssh public key to localhost

### DIFF
--- a/playbooks/dovetail.yml
+++ b/playbooks/dovetail.yml
@@ -1,4 +1,16 @@
 ---
+- hosts: localhost
+  tasks:
+   - name: Copy public key
+     command: cat ~/.ssh/id_rsa.pub
+     register: undercloud_ssh_key
+
+   - name: Append public key to authorized_key
+     lineinfile:
+       dest: ~/.ssh/authorized_keys
+       line: '{{ undercloud_ssh_key.stdout }}'
+       create: yes
+
 - name: Run dovetail
   hosts: undercloud
   gather_facts: no


### PR DESCRIPTION
When the role is invoked at undercloud, ansible's ssh require pass
because there is no authorized_keys. This fix injects it.

Signed-off-by: Tomofumi Hayashi <tohayash@redhat.com>